### PR TITLE
16 users endpoint

### DIFF
--- a/.github/prompts/javadoc.prompt.md
+++ b/.github/prompts/javadoc.prompt.md
@@ -1,0 +1,52 @@
+---
+agent: 'agent'
+description: 'Generate Javadoc comments and update existing ones if needed.'
+---
+
+Generate Javadoc comments and update existing ones if needed for  ${input:classOrMethod}.
+
+Ask me about ${input:classOrMethod} if it is not clear to you.
+
+# Javadoc best practices
+
+## 1. Start with a summary
+- Begin with a one-sentence summary describing what the class or method does.
+- End the summary sentence with a period.
+
+## 2. Describe parameters, return values, and exceptions
+- Use `@param` for each parameter (what it represents).
+- Use `@return` for methods that return a value.
+- Use `@throws` (or `@exception`) for thrown exceptions that callers should know about.
+
+## 3. Favor complete, clear, and concise language
+- Use correct grammar, punctuation, and terminology.
+- Use present tense and third person (e.g., “Returns…”, “Computes…”).
+- Write for an international audience; avoid idioms and slang.
+- Prefer concise descriptions without losing meaning.
+- Prefer clear terms and consistent naming in prose and examples.
+- Stick to the main points and avoid overcomplicating explanations.
+
+## 4. Use tags appropriately
+- Use `@deprecated` with clear migration guidance and an alternative API suggestion.
+- Use `@see`, `{@link ...}`, and `{@linkplain ...}` to connect related API elements.
+- Avoid `@author` (version control provides authorship).
+
+## 5. Explain the “why,” not just the “what”
+- Capture intent, constraints, tradeoffs, and important side effects.
+- Call out key behavioral contracts (e.g., thread-safety, immutability, synchronization expectations).
+
+## 6. Avoid redundancy
+- Don’t restate the method name or repeat what is obvious from the signature.
+- Don’t duplicate implementation details that are likely to change.
+
+## 7. Use HTML markup sparingly and correctly
+- Use simple HTML when it improves readability (`<p>`, `<ul>`, `<li>`, `<code>`, `<pre>`).
+- Avoid excessive formatting that reduces maintainability.
+
+## 8. Include code examples where they add real value
+- For non-trivial APIs, include short, focused usage examples (often best in `<pre><code>...</code></pre>`).
+- Keep examples correct, minimal, and representative.
+
+## 9. Don’t expose internals or sensitive information
+- Avoid documenting secrets, credentials, internal-only endpoints, or security-sensitive details.
+- Don’t leak implementation details that could become attack surfaces or lock you into internals.

--- a/src/main/java/io/kristixlab/notion/api/endpoints/UsersEndpoint.java
+++ b/src/main/java/io/kristixlab/notion/api/endpoints/UsersEndpoint.java
@@ -1,0 +1,44 @@
+package io.kristixlab.notion.api.endpoints;
+
+import io.kristixlab.notion.api.model.users.User;
+import io.kristixlab.notion.api.model.users.UserList;
+
+/**
+ * Defines operations for reading users from the Notion API.
+ *
+ * @see <a href="https://developers.notion.com/reference/users">Notion Users API</a>
+ */
+public interface UsersEndpoint {
+
+  /**
+   * Retrieves users with optional pagination parameters.
+   *
+   * @param startCursor cursor for the next page; {@code null} starts from the first page
+   * @param pageSize number of results to request per page
+   * @return a paginated list of users
+   */
+  UserList listUsers(String startCursor, Integer pageSize);
+
+  /**
+   * Retrieves the first page of users using Notion defaults.
+   *
+   * @return a paginated list of users
+   */
+  UserList listUsers();
+
+  /**
+   * Retrieves a user by identifier.
+   *
+   * @param userId the Notion user identifier
+   * @return the matching user
+   * @throws IllegalArgumentException if {@code userId} is {@code null}, empty, or blank
+   */
+  User retrieve(String userId);
+
+  /**
+   * Retrieves the bot user associated with the current authentication token.
+   *
+   * @return the current bot user
+   */
+  User me();
+}

--- a/src/main/java/io/kristixlab/notion/api/endpoints/impl/BaseEndpointImpl.java
+++ b/src/main/java/io/kristixlab/notion/api/endpoints/impl/BaseEndpointImpl.java
@@ -1,0 +1,56 @@
+package io.kristixlab.notion.api.endpoints.impl;
+
+import io.kristixlab.notion.api.http.base.client.ApiClient;
+import io.kristixlab.notion.api.http.base.request.ApiPath;
+
+/**
+ * Provides shared HTTP client access and common request helpers for endpoint implementations.
+ */
+public abstract class BaseEndpointImpl {
+
+  private final ApiClient client;
+
+  protected static final String GET = "GET";
+  protected static final String POST = "POST";
+  protected static final String PUT = "PUT";
+  protected static final String PATCH = "PATCH";
+  protected static final String DELETE = "DELETE";
+
+  /**
+   * Creates a base endpoint wrapper around the configured API client.
+   *
+   * @param client client used to execute API requests
+   */
+  public BaseEndpointImpl(ApiClient client) {
+    this.client = client;
+  }
+
+  /**
+   * Returns the API client used by this endpoint.
+   *
+   * @return the configured API client
+   */
+  protected ApiClient getClient() {
+    return client;
+  }
+
+  /**
+   * Creates an API path builder with optional Notion pagination query parameters.
+   *
+   * @param url endpoint path, for example {@code "/users"}
+   * @param startCursor pagination cursor; omitted when {@code null}
+   * @param pageSize page size to request; omitted when {@code null}
+   * @return a builder that can be further customized before {@link ApiPath.Builder#build()}
+   */
+  public static ApiPath.Builder paginatedPath(String url, String startCursor, Integer pageSize) {
+    ApiPath.Builder builder = ApiPath.builder(url);
+    if (startCursor != null) {
+      builder.queryParam("start_cursor", startCursor);
+    }
+    if (pageSize != null) {
+      builder.queryParam("page_size", String.valueOf(pageSize));
+    }
+    return builder;
+  }
+
+}

--- a/src/main/java/io/kristixlab/notion/api/endpoints/impl/BaseEndpointImpl.java
+++ b/src/main/java/io/kristixlab/notion/api/endpoints/impl/BaseEndpointImpl.java
@@ -3,9 +3,7 @@ package io.kristixlab.notion.api.endpoints.impl;
 import io.kristixlab.notion.api.http.base.client.ApiClient;
 import io.kristixlab.notion.api.http.base.request.ApiPath;
 
-/**
- * Provides shared HTTP client access and common request helpers for endpoint implementations.
- */
+/** Provides shared HTTP client access and common request helpers for endpoint implementations. */
 public abstract class BaseEndpointImpl {
 
   private final ApiClient client;
@@ -52,5 +50,4 @@ public abstract class BaseEndpointImpl {
     }
     return builder;
   }
-
 }

--- a/src/main/java/io/kristixlab/notion/api/endpoints/impl/UsersEndpointImpl.java
+++ b/src/main/java/io/kristixlab/notion/api/endpoints/impl/UsersEndpointImpl.java
@@ -8,9 +8,7 @@ import io.kristixlab.notion.api.http.base.request.ApiPath;
 import io.kristixlab.notion.api.model.users.User;
 import io.kristixlab.notion.api.model.users.UserList;
 
-/**
- * Provides access to Notion user resources for retrieving individual users and user listings.
- */
+/** Provides access to Notion user resources for retrieving individual users and user listings. */
 public class UsersEndpointImpl extends BaseEndpointImpl implements UsersEndpoint {
 
   private static final String USER_ID = "user_id";
@@ -67,5 +65,4 @@ public class UsersEndpointImpl extends BaseEndpointImpl implements UsersEndpoint
   public User me() {
     return getClient().call(GET, ApiPath.from("/users/me"), User.class);
   }
-
 }

--- a/src/main/java/io/kristixlab/notion/api/endpoints/impl/UsersEndpointImpl.java
+++ b/src/main/java/io/kristixlab/notion/api/endpoints/impl/UsersEndpointImpl.java
@@ -1,0 +1,71 @@
+package io.kristixlab.notion.api.endpoints.impl;
+
+import static io.kristixlab.notion.api.endpoints.util.Validator.*;
+
+import io.kristixlab.notion.api.endpoints.UsersEndpoint;
+import io.kristixlab.notion.api.http.base.client.ApiClient;
+import io.kristixlab.notion.api.http.base.request.ApiPath;
+import io.kristixlab.notion.api.model.users.User;
+import io.kristixlab.notion.api.model.users.UserList;
+
+/**
+ * Provides access to Notion user resources for retrieving individual users and user listings.
+ */
+public class UsersEndpointImpl extends BaseEndpointImpl implements UsersEndpoint {
+
+  private static final String USER_ID = "user_id";
+
+  /**
+   * Creates a users endpoint backed by the provided API client.
+   *
+   * @param client client used to execute user API requests
+   */
+  public UsersEndpointImpl(ApiClient client) {
+    super(client);
+  }
+
+  /**
+   * Retrieves a user by identifier.
+   *
+   * @param userId the Notion user identifier
+   * @return the matching user
+   * @throws IllegalArgumentException if {@code userId} is {@code null}, empty, or blank
+   */
+  public User retrieve(String userId) {
+    checkNotNullOrEmpty(userId, "userId");
+
+    ApiPath urlInfo = ApiPath.builder("/users/{user_id}").pathParam(USER_ID, userId).build();
+    return getClient().call(GET, urlInfo, User.class);
+  }
+
+  /**
+   * Retrieves the first page of users using Notion defaults.
+   *
+   * @return a paginated list of users
+   */
+  public UserList listUsers() {
+    return listUsers(null, null);
+  }
+
+  /**
+   * Retrieves users with optional pagination parameters.
+   *
+   * @param startCursor cursor for the next page; {@code null} starts from the first page
+   * @param pageSize number of results to request per page (maximum 100)
+   * @return a paginated list of users
+   */
+  public UserList listUsers(String startCursor, Integer pageSize) {
+    ApiPath.Builder path = paginatedPath("/users", startCursor, pageSize);
+    return getClient().call(GET, path.build(), UserList.class);
+  }
+
+  /**
+   * Retrieves the bot user associated with the current authentication token.
+   *
+   * @return the current bot user
+   */
+  public User me() {
+    return getClient().call(GET, ApiPath.from("/users/me"), User.class);
+  }
+
+}

--- a/src/main/java/io/kristixlab/notion/api/endpoints/util/Validator.java
+++ b/src/main/java/io/kristixlab/notion/api/endpoints/util/Validator.java
@@ -1,0 +1,32 @@
+package io.kristixlab.notion.api.endpoints.util;
+
+public class Validator {
+
+  private Validator() {}
+
+  /**
+   * Validates that a string value is present and contains non-whitespace characters.
+   *
+   * @param value value to validate
+   * @param valueName value name used in error messages
+   * @throws IllegalArgumentException if {@code value} is {@code null}, empty, or blank
+   */
+  public static void checkNotNullOrEmpty(String value, String valueName) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(valueName + " cannot be null, empty, or blank");
+    }
+  }
+
+  /**
+   * Validates that an object reference is not {@code null}.
+   *
+   * @param object object to validate
+   * @param objectName object name used in error messages
+   * @throws IllegalArgumentException if {@code object} is {@code null}
+   */
+  public static void checkNotNull(Object object, String objectName) {
+    if (object == null) {
+      throw new IllegalArgumentException(objectName + " cannot be null");
+    }
+  }
+}

--- a/src/main/java/io/kristixlab/notion/api/http/base/request/ApiPath.java
+++ b/src/main/java/io/kristixlab/notion/api/http/base/request/ApiPath.java
@@ -9,16 +9,15 @@ import lombok.Getter;
  * Immutable API path with optional path and query parameters. Created via {@link #from(String)} or
  * the fluent {@link Builder}.
  */
-@Getter
 public final class ApiPath {
 
-  private final String url;
+  @Getter private final String url;
 
   /** Unmodifiable map of path parameters. */
-  private final Map<String, String> pathParams;
+  @Getter private final Map<String, String> pathParams;
 
   /** Unmodifiable map of query parameters. */
-  private final Map<String, List<String>> queryParams;
+  @Getter private final Map<String, List<String>> queryParams;
 
   private ApiPath(
       String url, Map<String, String> pathParams, Map<String, List<String>> queryParams) {

--- a/src/main/java/io/kristixlab/notion/api/http/error/NotionApiException.java
+++ b/src/main/java/io/kristixlab/notion/api/http/error/NotionApiException.java
@@ -1,14 +1,15 @@
 package io.kristixlab.notion.api.http.error;
 
+import lombok.Getter;
+
 /**
  * Base exception for all Notion API errors. Carries the HTTP status, Notion error code, and request
  * ID for diagnostics.
  */
 public class NotionApiException extends RuntimeException {
-
-  private final int status;
-  private final String code;
-  private final String requestId;
+  @Getter private final int status;
+  @Getter private final String code;
+  @Getter private final String requestId;
 
   public NotionApiException(int status, String code, String message, String requestId) {
     super(message);
@@ -21,17 +22,5 @@ public class NotionApiException extends RuntimeException {
     return String.format(
         "%s\n Notion API Exception - Status: %d, Code: %s, Message: %s, Request ID: %s",
         this.getClass().getName(), status, code, getMessage(), requestId);
-  }
-
-  public int getStatus() {
-    return status;
-  }
-
-  public String getCode() {
-    return code;
-  }
-
-  public String getRequestId() {
-    return requestId;
   }
 }

--- a/src/main/java/io/kristixlab/notion/api/model/BaseNotionObject.java
+++ b/src/main/java/io/kristixlab/notion/api/model/BaseNotionObject.java
@@ -1,14 +1,11 @@
 package io.kristixlab.notion.api.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 public class BaseNotionObject {
 
-  @JsonProperty("object")
   private String object; // e.g., "list", "block", "page", "property_item", etc.
 
-  @JsonProperty("request_id")
   private String requestId;
 }

--- a/src/main/java/io/kristixlab/notion/api/model/NotionError.java
+++ b/src/main/java/io/kristixlab/notion/api/model/NotionError.java
@@ -1,39 +1,30 @@
 package io.kristixlab.notion.api.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Data;
 
 @Data
 public class NotionError extends BaseNotionObject {
 
-  @JsonProperty("error")
   private String error;
 
-  @JsonProperty("status")
   private Integer status;
 
-  @JsonProperty("code")
   private String code;
 
-  @JsonProperty("message")
   private String message;
 
-  @JsonProperty("additional_data")
   private AdditionalData additionalData;
 
   @Data
   public static class AdditionalData {
-    @JsonProperty("error_type")
+
     private String errorType;
 
-    @JsonProperty("database_id")
     private String databaseId;
 
-    @JsonProperty("child_data_source_ids")
     private List<String> childDataSourceIds;
 
-    @JsonProperty("minimum_api_version")
     private String minimumApiVersion;
   }
 }

--- a/src/main/java/io/kristixlab/notion/api/model/NotionError.java
+++ b/src/main/java/io/kristixlab/notion/api/model/NotionError.java
@@ -3,9 +3,7 @@ package io.kristixlab.notion.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
-@EqualsAndHashCode(callSuper = true)
 @Data
 public class NotionError extends BaseNotionObject {
 

--- a/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
+++ b/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
@@ -11,7 +11,7 @@ public class NotionListType<T> extends BaseNotionObject {
 
   private String type;
 
-  private boolean hasMore;
+  private Boolean hasMore;
 
   private String nextCursor;
 }

--- a/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
+++ b/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
@@ -3,17 +3,15 @@ package io.kristixlab.notion.api.model.common;
 import io.kristixlab.notion.api.model.BaseNotionObject;
 import java.util.List;
 import lombok.Data;
-import lombok.experimental.Accessors;
 
 @Data
 public class NotionListType<T> extends BaseNotionObject {
 
   private List<T> results;
 
-  private String nextCursor;
-
-  @Accessors(fluent = true)
-  private Boolean hasMore;
-
   private String type;
+
+  private boolean hasMore;
+
+  private String nextCursor;
 }

--- a/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
+++ b/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
@@ -1,0 +1,24 @@
+package io.kristixlab.notion.api.model.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kristixlab.notion.api.model.BaseNotionObject;
+import java.util.List;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+public class NotionListType<T> extends BaseNotionObject {
+
+  @JsonProperty("results")
+  private List<T> results;
+
+  @JsonProperty("next_cursor")
+  private String nextCursor;
+
+  @Accessors(fluent = true)
+  @JsonProperty("has_more")
+  private Boolean hasMore;
+
+  @JsonProperty("type")
+  private String type;
+}

--- a/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
+++ b/src/main/java/io/kristixlab/notion/api/model/common/NotionListType.java
@@ -1,6 +1,5 @@
 package io.kristixlab.notion.api.model.common;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kristixlab.notion.api.model.BaseNotionObject;
 import java.util.List;
 import lombok.Data;
@@ -9,16 +8,12 @@ import lombok.experimental.Accessors;
 @Data
 public class NotionListType<T> extends BaseNotionObject {
 
-  @JsonProperty("results")
   private List<T> results;
 
-  @JsonProperty("next_cursor")
   private String nextCursor;
 
   @Accessors(fluent = true)
-  @JsonProperty("has_more")
   private Boolean hasMore;
 
-  @JsonProperty("type")
   private String type;
 }

--- a/src/main/java/io/kristixlab/notion/api/model/users/Bot.java
+++ b/src/main/java/io/kristixlab/notion/api/model/users/Bot.java
@@ -1,0 +1,15 @@
+package io.kristixlab.notion.api.model.users;
+
+import lombok.Data;
+
+@Data
+public class Bot {
+
+  private Owner owner;
+
+  private String workspaceName;
+
+  private String workspaceId;
+
+  private WorkspaceLimits workspaceLimits;
+}

--- a/src/main/java/io/kristixlab/notion/api/model/users/Owner.java
+++ b/src/main/java/io/kristixlab/notion/api/model/users/Owner.java
@@ -1,0 +1,13 @@
+package io.kristixlab.notion.api.model.users;
+
+import lombok.Data;
+
+@Data
+public class Owner {
+
+  private String type;
+
+  private Boolean workspace;
+
+  private User user;
+}

--- a/src/main/java/io/kristixlab/notion/api/model/users/User.java
+++ b/src/main/java/io/kristixlab/notion/api/model/users/User.java
@@ -1,26 +1,20 @@
 package io.kristixlab.notion.api.model.users;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kristixlab.notion.api.model.BaseNotionObject;
 import lombok.Data;
 
 @Data
-public class User {
+public class User extends BaseNotionObject {
 
-  @JsonProperty("object")
-  private String object;
-
-  @JsonProperty("id")
   private String id;
 
-  @JsonProperty("name")
   private String name;
 
-  @JsonProperty("avatar_url")
   private String avatarUrl;
 
-  @JsonProperty("type")
   private String type;
 
-  @JsonProperty("person")
   private Person person;
+
+  private Bot bot;
 }

--- a/src/main/java/io/kristixlab/notion/api/model/users/UserList.java
+++ b/src/main/java/io/kristixlab/notion/api/model/users/UserList.java
@@ -1,0 +1,10 @@
+package io.kristixlab.notion.api.model.users;
+
+import io.kristixlab.notion.api.model.common.NotionListType;
+import lombok.Data;
+
+@Data
+public class UserList extends NotionListType<User> {
+
+  private Object user;
+}

--- a/src/main/java/io/kristixlab/notion/api/model/users/WorkspaceLimits.java
+++ b/src/main/java/io/kristixlab/notion/api/model/users/WorkspaceLimits.java
@@ -3,7 +3,7 @@ package io.kristixlab.notion.api.model.users;
 import lombok.Data;
 
 @Data
-public class Person {
+public class WorkspaceLimits {
 
-  private String email;
+  private Long maxFileUploadSizeInBytes;
 }

--- a/src/test/java/io/kristixlab/notion/api/endpoints/impl/UsersEndpointImplTest.java
+++ b/src/test/java/io/kristixlab/notion/api/endpoints/impl/UsersEndpointImplTest.java
@@ -1,0 +1,88 @@
+package io.kristixlab.notion.api.endpoints.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.kristixlab.notion.api.http.base.client.ApiClientStub;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UsersEndpointImplTest {
+
+  private ApiClientStub client;
+  private UsersEndpointImpl endpoint;
+
+  @BeforeEach
+  void setUp() {
+    client = new ApiClientStub();
+    endpoint = new UsersEndpointImpl(client);
+  }
+
+  @Test
+  void retrieveById() {
+    endpoint.retrieve("user-id-42");
+
+    assertEquals("GET", client.getLastMethod());
+    assertEquals("/users/{user_id}", client.getLastUrlInfo().getUrl());
+    assertEquals("user-id-42", client.getLastUrlInfo().getPathParams().get("user_id"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void retrieve_rejectsBlankOrNullUserId(String userId) {
+    assertThrows(IllegalArgumentException.class, () -> endpoint.retrieve(userId));
+  }
+
+  @Test
+  void listUsers() {
+    endpoint.listUsers();
+
+    assertEquals("GET", client.getLastMethod());
+    assertEquals("/users", client.getLastUrlInfo().getUrl());
+    assertTrue(client.getLastUrlInfo().getQueryParams().isEmpty());
+  }
+
+  @Test
+  void listUsers_withStartCursor() {
+    endpoint.listUsers("cursor-xyz", null);
+
+    assertEquals("GET", client.getLastMethod());
+    assertEquals("/users", client.getLastUrlInfo().getUrl());
+    assertEquals(
+        List.of("cursor-xyz"), client.getLastUrlInfo().getQueryParams().get("start_cursor"));
+    assertFalse(client.getLastUrlInfo().getQueryParams().containsKey("page_size"));
+  }
+
+  @Test
+  void listUsers_withPageSize() {
+    endpoint.listUsers(null, 50);
+
+    assertEquals("GET", client.getLastMethod());
+    assertEquals("/users", client.getLastUrlInfo().getUrl());
+    assertEquals(List.of("50"), client.getLastUrlInfo().getQueryParams().get("page_size"));
+    assertFalse(client.getLastUrlInfo().getQueryParams().containsKey("start_cursor"));
+  }
+
+  @Test
+  void listUsers_withBothPaginationParams() {
+    endpoint.listUsers("cursor-abc", 25);
+
+    assertEquals("GET", client.getLastMethod());
+    assertEquals("/users", client.getLastUrlInfo().getUrl());
+    assertEquals(
+        List.of("cursor-abc"), client.getLastUrlInfo().getQueryParams().get("start_cursor"));
+    assertEquals(List.of("25"), client.getLastUrlInfo().getQueryParams().get("page_size"));
+  }
+
+  @Test
+  void me() {
+    endpoint.me();
+
+    assertEquals("GET", client.getLastMethod());
+    assertEquals("/users/me", client.getLastUrlInfo().getUrl());
+  }
+}

--- a/src/test/java/io/kristixlab/notion/api/endpoints/util/ValidatorTest.java
+++ b/src/test/java/io/kristixlab/notion/api/endpoints/util/ValidatorTest.java
@@ -1,0 +1,57 @@
+package io.kristixlab.notion.api.endpoints.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ValidatorTest {
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void checkNotNullOrEmpty_shouldThrowException_whenValueIsNull(String value) {
+    String valueName = "testValue";
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Validator.checkNotNullOrEmpty(value, valueName);
+        });
+  }
+
+  @Test
+  void checkNotNullOrEmpty_shouldNotThrowException_whenValueIsValid() {
+    String value = "valid";
+    String valueName = "testValue";
+
+    assertDoesNotThrow(
+        () -> {
+          Validator.checkNotNullOrEmpty(value, valueName);
+        });
+  }
+
+  @Test
+  void checkNotNull_shouldThrowException_whenValueIsNull() {
+    String valueName = "testValue";
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          Validator.checkNotNullOrEmpty(null, valueName);
+        });
+  }
+
+  @Test
+  void checkNotNull_shouldNotThrowException_whenValueIsValid() {
+    Object value = new Object();
+    String valueName = "testValue";
+
+    assertDoesNotThrow(
+        () -> {
+          Validator.checkNotNull(value, valueName);
+        });
+  }
+}

--- a/src/test/java/io/kristixlab/notion/api/endpoints/util/ValidatorTest.java
+++ b/src/test/java/io/kristixlab/notion/api/endpoints/util/ValidatorTest.java
@@ -37,11 +37,14 @@ public class ValidatorTest {
   void checkNotNull_shouldThrowException_whenValueIsNull() {
     String valueName = "testValue";
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          Validator.checkNotNull(null, valueName);
-        });
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              Validator.checkNotNull(null, valueName);
+            });
+
+    assertEquals("testValue cannot be null", exception.getMessage());
   }
 
   @Test

--- a/src/test/java/io/kristixlab/notion/api/endpoints/util/ValidatorTest.java
+++ b/src/test/java/io/kristixlab/notion/api/endpoints/util/ValidatorTest.java
@@ -40,7 +40,7 @@ public class ValidatorTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          Validator.checkNotNullOrEmpty(null, valueName);
+          Validator.checkNotNull(null, valueName);
         });
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new API surface for `/users` plus new/changed JSON models, which could affect deserialization compatibility (notably removal of explicit `@JsonProperty` mappings) if naming strategy differs from expectations.
> 
> **Overview**
> Adds a new `UsersEndpoint` (and `UsersEndpointImpl`) to call Notion’s Users API, supporting `retrieve(userId)`, `me()`, and `listUsers()` with optional pagination via a shared `BaseEndpointImpl.paginatedPath` helper.
> 
> Introduces user-related response models (`UserList`, `Bot`, `Owner`, `WorkspaceLimits`) and a generic `NotionListType<T>` base for list responses, and updates `User` to extend `BaseNotionObject` and include bot details.
> 
> Refactors a few core types to rely on Lombok-generated getters (e.g., `ApiPath`, `NotionApiException`) and removes several explicit Jackson `@JsonProperty` annotations from model classes, plus adds unit tests for the new users endpoint and input validation utilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e50c92fa5c0769d78c7155c59bf1a47a2389335. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->